### PR TITLE
Add serviceLBAnnotations for aws load balancer controller

### DIFF
--- a/templates/acorn-install.yaml
+++ b/templates/acorn-install.yaml
@@ -41,6 +41,11 @@ data:
       "builderPerProject": true,
       "publishBuilders": true,
       "internalRegistryPrefix": "null.acrn.io/"
+      "serviceLBAnnotations": {
+        "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "instance",
+        "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+        "service.beta.kubernetes.io/aws-load-balancer-type": "external"
+      }
     }
 ---
 apiVersion: batch/v1


### PR DESCRIPTION
> **Note**: Depends on https://github.com/acorn-io/acorn-k8s-resources/pull/319 merging and being tested

Adding the new `serviceLBAnnotations` flag that was added in https://github.com/acorn-io/acorn/pull/1417.