### PR TITLE
Fix Datadog Agent site value

### DIFF
--- a/templates/datadog-agent.yaml
+++ b/templates/datadog-agent.yaml
@@ -27,7 +27,7 @@ spec:
   valuesContent: |
     datadog:
       apiKeyExistingSecret: datadog-api-key
-      site: datadoghq.com
+      site: us3.datadoghq.com
       clusterName: {{ .Values.clusterName }}
       podLabelsAsTags:
         "acorn.io/app-name": acorn_io_app_name


### PR DESCRIPTION
I forgot to change this one. Our company's Datadog account is on their US3 site.