### PR TITLE
Fix template file for Prometheus

### DIFF
--- a/templates/prometheus-chart.yaml
+++ b/templates/prometheus-chart.yaml
@@ -94,3 +94,4 @@ spec:
         kubernetesStorage: false
         kubernetesSystem: false
         kubeScheduler: false
+{{- end }}


### PR DESCRIPTION
This Prometheus template file was missing the `{{ end }}` so I added that in. `helm lint` no longer shows any issues with the chart.