### PR TITLE
Disable Istiod HPA

### DIFF
--- a/templates/istio.yaml
+++ b/templates/istio.yaml
@@ -46,7 +46,7 @@ spec:
               "use_openmetrics": "true"
             }
           ]
-      autoscaleMin: 2
+      autoscaleEnabled: false
       replicaCount: 2
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
Right now with the way that podAntiAffinity is set up on Istio, it will always fail to schedule a third pod if it ever tries to scale up to that, since the podAntiAffinity is strict (`requiredDuringSchedulingIgnoredDuringExecution`).

If we wanted to get around this problem, we could change it to `preferredDuringSchedulingIgnoredDuringExecution`, but that would have the added risk that both of the pods end up on the master node when the cluster is first provisioned, and neither of them move over to the worker node. If we wanted to try this, one possible workaround would be to extend the acorn-istio-plugin to watch for when this happens and intentionally delete one of the two pods on the master node so that it reschedules onto the worker node. Interested in hearing your thoughts @StrongMonkey @tylerslaton. For now I think it's best to just disable autoscaling.