### PR TITLE
acorn-istio-plugin: add new permissions

### DIFF
--- a/templates/hub-resources.yaml
+++ b/templates/hub-resources.yaml
@@ -146,7 +146,16 @@ spec:
       - security.istio.io
       resources:
       - peerauthentications
+      - peerauthentications/status
       - authorizationpolicies
+      - authorizationpolicies/status
+      verbs:
+      - '*'
+    - apiGroups:
+      - networking.istio.io
+      resources:
+      - virtualservices
+      - virtualservices/status
       verbs:
       - '*'
     - apiGroups:


### PR DESCRIPTION
These permissions were recently added to acorn-istio-plugin to eliminate some errors and properly handle service linking. They need to be added here as well in order for them to actually work in provisioned clusters.