### PR TITLE
Only install Prometheus when absolutely ready

### DIFF
--- a/templates/prometheus-chart.yaml
+++ b/templates/prometheus-chart.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus && .Values.prometheusRemoteWriteRoleArn }}
+{{ if and .Values.prometheus .Values.prometheusRemoteWriteRoleArn }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/prometheus-chart.yaml
+++ b/templates/prometheus-chart.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheus }}
+{{ if .Values.prometheus && .Values.prometheusRemoteWriteRoleArn }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/templates/prometheus-instance.yaml
+++ b/templates/prometheus-instance.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheusInstance && .Values.prometheusRemoteWriteRoleArn }}
+{{ if and .Values.prometheusInstance .Values.prometheusRemoteWriteRoleArn }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus

--- a/templates/prometheus-instance.yaml
+++ b/templates/prometheus-instance.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.prometheusInstance }}
+{{ if .Values.prometheusInstance && .Values.prometheusRemoteWriteRoleArn }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus


### PR DESCRIPTION
My changes result in several reinstallation attempts of the Helm chart as things in AWS reconcile, and this seems to cause it to hiccup a little bit and sometimes get into a stuck state. If we wait to install Prometheus until we have all the information that we need, that might help us to avoid that situation.