### PR TITLE
Add more relabel configs to istio scrape secret

### DIFF
--- a/templates/prometheus-instance.yaml
+++ b/templates/prometheus-instance.yaml
@@ -100,6 +100,7 @@ stringData:
       metrics_path: /stats/prometheus
       kubernetes_sd_configs:
       - role: pod
+
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_container_port_name]
         action: keep
@@ -107,6 +108,28 @@ stringData:
       - action: labelmap
         regex: __meta_kubernetes_pod_label_acorn_io_(.+)
         replacement: acorn_io_${1}
+
+      metric_relabel_configs:
+      - action: replace
+        source_labels: [__name__, source_canonical_service]
+        regex: '(istio_request_bytes_sum|istio_tcp_sent_bytes_total);(.*)'
+        target_label: source
+        replacement: ${2}
+      - action: replace
+        source_labels: [__name__, destination_canonical_service]
+        regex: '(istio_request_bytes_sum|istio_tcp_sent_bytes_total);(.*)'
+        target_label: dest
+        replacement: ${2}
+      - action: replace
+        source_labels: [__name__, destination_canonical_service]
+        regex: '(istio_response_bytes_sum|istio_tcp_received_bytes_total);(.*)'
+        target_label: source
+        replacement: ${2}
+      - action: replace
+        source_labels: [__name__, source_canonical_service]
+        regex: '(istio_response_bytes_sum|istio_tcp_received_bytes_total);(.*)'
+        target_label: dest
+        replacement: ${2}
 metadata:
   name: istio-proxy-scrape-config
   namespace: prometheus-operator


### PR DESCRIPTION
This is needed in order to support the tcp-flow metric in prom-ws.